### PR TITLE
Add a test case for simple structure objects

### DIFF
--- a/tree/tree/inc/ROOT/TBulkBranchRead.hxx
+++ b/tree/tree/inc/ROOT/TBulkBranchRead.hxx
@@ -22,10 +22,10 @@ class TBulkBranchRead {
    friend class ::TBranch;
 
 public:
-   Int_t  GetEntriesFast(Long64_t evt, TBuffer& user_buf) {return fParent.GetEntriesFast(evt, user_buf);}
-   Int_t  GetEntriesSerialized(Long64_t evt, TBuffer& user_buf) {return fParent.GetEntriesSerialized(evt, user_buf);}
-   Int_t  GetEntriesSerialized(Long64_t evt, TBuffer& user_buf, TBuffer* count_buf) {return fParent.GetEntriesSerialized(evt, user_buf, count_buf);}
-   Bool_t SupportsBulkRead() const {return fParent.SupportsBulkRead();}
+   Int_t  GetEntriesFast(Long64_t evt, TBuffer& user_buf) { return fParent.GetEntriesFast(evt, user_buf); }
+   Int_t  GetEntriesSerialized(Long64_t evt, TBuffer& user_buf) { return fParent.GetEntriesSerialized(evt, user_buf); }
+   Int_t  GetEntriesSerialized(Long64_t evt, TBuffer& user_buf, TBuffer* count_buf) { return fParent.GetEntriesSerialized(evt, user_buf, count_buf); }
+   Bool_t SupportsBulkRead() const { return fParent.SupportsBulkRead(); }
 
 private:
    TBulkBranchRead(TBranch &parent)

--- a/tree/tree/inc/TBranch.h
+++ b/tree/tree/inc/TBranch.h
@@ -85,6 +85,7 @@ protected:
       kDoNotUseBufferMap = BIT(22) // If set, at least one of the entry in the branch will use the buffer's map of classname and objects.
    };
 
+   typedef std::unique_ptr<ROOT::Experimental::Internal::TBulkBranchRead> BulkPtr;
    static Int_t fgCount;          ///<! branch counter
    Int_t       fCompress;         ///<  Compression level and algorithm
    Int_t       fBasketSize;       ///<  Initial Size of  Basket Buffer
@@ -122,7 +123,7 @@ protected:
    TBuffer    *fEntryBuffer;      ///<! Buffer used to directly pass the content without streaming
    TBuffer    *fTransientBuffer;  ///<! Pointer to the current transient buffer.
    TList      *fBrowsables;       ///<! List of TVirtualBranchBrowsables used for Browse()
-   std::unique_ptr<ROOT::Experimental::Internal::TBulkBranchRead> fBulk; ///<! Helper for performing bulk IO
+   BulkPtr     fBulk; ///<! Helper for performing bulk IO
 
    Bool_t      fSkipZip;          ///<! After being read, the buffer will not be unzipped.
 

--- a/tree/tree/inc/TLeaf.h
+++ b/tree/tree/inc/TLeaf.h
@@ -59,7 +59,7 @@ public:
       kNewValue = BIT(12)         ///< Set if we own the value buffer and so must delete it ourselves.
    };
 
-   enum DeserializeType{
+   enum DeserializeType {
       kInvalid = 0,      // Invalid deserialization information.
       kDestructive = 0,  // Deserialization of this Leaf requires a separate output buffer.
       kInPlace,          // Deserialization can be done directly in the input buffer.

--- a/tree/tree/inc/TLeafD.h
+++ b/tree/tree/inc/TLeafD.h
@@ -39,9 +39,9 @@ public:
    virtual void    Export(TClonesArray *list, Int_t n);
    virtual void    FillBasket(TBuffer &b);
    virtual DeserializeType GetDeserializeType() const { return kInPlace; }
-   const char     *GetTypeName() const {return "Double_t";}
+   const char     *GetTypeName() const { return "Double_t"; }
    Double_t        GetValue(Int_t i=0) const;
-   virtual void   *GetValuePointer() const {return fValue;}
+   virtual void   *GetValuePointer() const { return fValue; }
    virtual void    Import(TClonesArray *list, Int_t n);
    virtual void    PrintValue(Int_t i=0) const;
    virtual void    ReadBasket(TBuffer &b);
@@ -50,7 +50,7 @@ public:
    virtual void    SetAddress(void *add=0);
 
    virtual bool    ReadBasketFast(TBuffer&, Long64_t);
-   virtual bool    ReadBasketSerialized(TBuffer&, Long64_t) {return GetDeserializeType() == kInPlace; }
+   virtual bool    ReadBasketSerialized(TBuffer&, Long64_t) { return GetDeserializeType() == kInPlace; }
 
    ClassDef(TLeafD,1);  //A TLeaf for a 64 bit floating point data type.
 };

--- a/tree/tree/inc/TLeafF.h
+++ b/tree/tree/inc/TLeafF.h
@@ -39,9 +39,9 @@ public:
    virtual void    Export(TClonesArray *list, Int_t n);
    virtual void    FillBasket(TBuffer &b);
    virtual DeserializeType GetDeserializeType() const { return kInPlace; }
-   const char     *GetTypeName() const {return "Float_t";}
+   const char     *GetTypeName() const { return "Float_t"; }
    Double_t        GetValue(Int_t i=0) const;
-   virtual void   *GetValuePointer() const {return fValue;}
+   virtual void   *GetValuePointer() const { return fValue; }
    virtual void    Import(TClonesArray *list, Int_t n);
    virtual void    PrintValue(Int_t i=0) const;
    virtual void    ReadBasket(TBuffer &b);
@@ -50,7 +50,7 @@ public:
    virtual void    SetAddress(void *add=0);
 
    virtual bool    ReadBasketFast(TBuffer&, Long64_t);
-   virtual bool    ReadBasketSerialized(TBuffer&, Long64_t) {return true;}
+   virtual bool    ReadBasketSerialized(TBuffer&, Long64_t) { return true; }
 
    ClassDef(TLeafF,1);  //A TLeaf for a 32 bit floating point data type.
 };

--- a/tree/tree/inc/TLeafI.h
+++ b/tree/tree/inc/TLeafI.h
@@ -41,17 +41,17 @@ public:
    virtual void    FillBasket(TBuffer &b);
    virtual DeserializeType GetDeserializeType() const { return kInPlace; }
    const char     *GetTypeName() const;
-   virtual Int_t   GetMaximum() const {return fMaximum;}
-   virtual Int_t   GetMinimum() const {return fMinimum;}
+   virtual Int_t   GetMaximum() const { return fMaximum; }
+   virtual Int_t   GetMinimum() const { return fMinimum; }
    Double_t        GetValue(Int_t i=0) const;
-   virtual void   *GetValuePointer() const {return fValue;}
+   virtual void   *GetValuePointer() const { return fValue; }
    virtual Bool_t  IncludeRange(TLeaf *);
    virtual void    Import(TClonesArray *list, Int_t n);
    virtual void    PrintValue(Int_t i=0) const;
    virtual void    ReadBasket(TBuffer &b);
    virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
    virtual bool    ReadBasketFast(TBuffer&, Long64_t);
-   virtual bool    ReadBasketSerialized(TBuffer&, Long64_t) {return GetDeserializeType() == kInPlace; }
+   virtual bool    ReadBasketSerialized(TBuffer&, Long64_t) { return GetDeserializeType() == kInPlace; }
    virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
    virtual void    SetAddress(void *add=0);
    virtual void    SetMaximum(Int_t max) {fMaximum = max;}

--- a/tree/tree/inc/TLeafL.h
+++ b/tree/tree/inc/TLeafL.h
@@ -40,19 +40,19 @@ public:
    virtual void    Export(TClonesArray *list, Int_t n);
    virtual void    FillBasket(TBuffer &b);
    const char     *GetTypeName() const;
-   virtual Int_t   GetMaximum() const {return (Int_t)fMaximum;}
-   virtual Int_t   GetMinimum() const {return (Int_t)fMinimum;}
+   virtual Int_t   GetMaximum() const { return (Int_t)fMaximum; }
+   virtual Int_t   GetMinimum() const { return (Int_t)fMinimum; }
    virtual Double_t     GetValue(Int_t i=0) const;
    virtual Long64_t     GetValueLong64(Int_t i = 0) const ;
    virtual LongDouble_t GetValueLongDouble(Int_t i = 0) const;
-   virtual void   *GetValuePointer() const {return fValue;}
+   virtual void   *GetValuePointer() const { return fValue; }
    virtual Bool_t  IncludeRange(TLeaf *);
    virtual void    Import(TClonesArray *list, Int_t n);
    virtual void    PrintValue(Int_t i=0) const;
    virtual void    ReadBasket(TBuffer &b);
    virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
    virtual bool    ReadBasketFast(TBuffer&, Long64_t);
-   virtual bool    ReadBasketSerialized(TBuffer&, Long64_t) {return GetDeserializeType() == kInPlace; }
+   virtual bool    ReadBasketSerialized(TBuffer&, Long64_t) { return GetDeserializeType() == kInPlace; }
    virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
    virtual void    SetAddress(void *add=0);
    virtual void    SetMaximum(Long64_t max) {fMaximum = max;}

--- a/tree/tree/inc/TLeafS.h
+++ b/tree/tree/inc/TLeafS.h
@@ -42,14 +42,14 @@ public:
    virtual Int_t   GetMinimum() const { return fMinimum; }
    const char     *GetTypeName() const;
    Double_t        GetValue(Int_t i=0) const;
-   virtual void   *GetValuePointer() const {return fValue;}
+   virtual void   *GetValuePointer() const { return fValue; }
    virtual Bool_t  IncludeRange(TLeaf *);
    virtual void    Import(TClonesArray *list, Int_t n);
    virtual void    PrintValue(Int_t i=0) const;
    virtual void    ReadBasket(TBuffer &b);
    virtual void    ReadBasketExport(TBuffer &b, TClonesArray *list, Int_t n);
    virtual bool    ReadBasketFast(TBuffer&, Long64_t);
-   virtual bool    ReadBasketSerialized(TBuffer&, Long64_t) {return GetDeserializeType() == kInPlace; }
+   virtual bool    ReadBasketSerialized(TBuffer&, Long64_t) { return GetDeserializeType() == kInPlace; }
    virtual void    ReadValue(std::istream& s, Char_t delim = ' ');
    virtual void    SetAddress(void *add=0);
    virtual void    SetMaximum(Short_t max) { fMaximum = max; }

--- a/tree/tree/src/TBranch.cxx
+++ b/tree/tree/src/TBranch.cxx
@@ -1438,16 +1438,25 @@ Int_t TBranch::GetEntriesFast(Long64_t entry, TBuffer &user_buf)
    TBuffer* buf = basket->GetBufferRef();
 
    // Test for very old ROOT files.
-   if (R__unlikely(!buf)) {Error("GetEntriesFast", "Failed to get a new buffer.\n"); return -1;}
+   if (R__unlikely(!buf)) {
+      Error("GetEntriesFast", "Failed to get a new buffer.\n");
+      return -1;
+   }
    // Test for displacements, which aren't supported in fast mode.
-   if (R__unlikely(basket->GetDisplacement())) {Error("GetEntriesFast", "Basket has displacement.\n"); return -1;}
+   if (R__unlikely(basket->GetDisplacement())) {
+      Error("GetEntriesFast", "Basket has displacement.\n");
+      return -1;
+   }
 
    Int_t bufbegin = basket->GetKeylen();
    buf->SetBufferOffset(bufbegin);
 
    Int_t N = ((fNextBasketEntry < 0) ? fEntryNumber : fNextBasketEntry) - first;
    //printf("Requesting %d events; fNextBasketEntry=%lld; first=%lld.\n", N, fNextBasketEntry, first);
-   if (R__unlikely(!leaf->ReadBasketFast(*buf, N))) {Error("GetEntriesFast", "Leaf failed to read.\n"); return -1;}
+   if (R__unlikely(!leaf->ReadBasketFast(*buf, N))) {
+      Error("GetEntriesFast", "Leaf failed to read.\n");
+      return -1;
+   }
    user_buf.SetBufferOffset(bufbegin);
 
    fCurrentBasket = nullptr;
@@ -1460,11 +1469,10 @@ Int_t TBranch::GetEntriesFast(Long64_t entry, TBuffer &user_buf)
 
 // TODO: Template this and the call above; only difference is the TLeaf function (ReadBasketFast vs
 // ReadBasketSerialized
-Int_t
-TBranch::GetEntriesSerialized(Long64_t entry, TBuffer &user_buf, TBuffer *count_buf)
+Int_t TBranch::GetEntriesSerialized(Long64_t entry, TBuffer &user_buf, TBuffer *count_buf)
 {
    // TODO: eventually support multiple leaves.
-   if (R__unlikely(fNleaves != 1)) {return -1;}
+   if (R__unlikely(fNleaves != 1)) { return -1; }
    TLeaf *leaf = static_cast<TLeaf*>(fLeaves.UncheckedAt(0));
    if (R__unlikely(leaf->GetDeserializeType() == TLeaf::DeserializeType::kDestructive)) {
       Error("GetEntriesSerialized", "Encountered a branch with destructive deserialization; failing.\n");
@@ -1475,11 +1483,11 @@ TBranch::GetEntriesSerialized(Long64_t entry, TBuffer &user_buf, TBuffer *count_
    fReadEntry = entry;
 
    Bool_t enabled = !TestBit(kDoNotProcess);
-   if (R__unlikely(!enabled)) {return -1;}
+   if (R__unlikely(!enabled)) { return -1; }
    TBasket *basket = nullptr;
    Long64_t first;
    Int_t result = GetBasketAndFirst(basket, first, &user_buf);
-   if (R__unlikely(result <= 0)) {return -1;}
+   if (R__unlikely(result <= 0)) { return -1; }
    // Only support reading from full clusters.
    if (R__unlikely(entry != first)) {
        Error("GetEntriesSerialized", "Failed to read from full cluster; first entry is %lld; requested entry is %lld.\n", first, entry);
@@ -1490,9 +1498,15 @@ TBranch::GetEntriesSerialized(Long64_t entry, TBuffer &user_buf, TBuffer *count_
    TBuffer* buf = basket->GetBufferRef();
 
    // Test for very old ROOT files.
-   if (R__unlikely(!buf)) {Error("GetEntriesSerialized", "Failed to get a new buffer.\n"); return -1;}
+   if (R__unlikely(!buf)) {
+      Error("GetEntriesSerialized", "Failed to get a new buffer.\n");
+      return -1;
+   }
    // Test for displacements, which aren't supported in fast mode.
-   if (R__unlikely(basket->GetDisplacement())) {Error("GetEntriesSerialized", "Basket has displacement.\n"); return -1;}
+   if (R__unlikely(basket->GetDisplacement())) {
+      Error("GetEntriesSerialized", "Basket has displacement.\n");
+      return -1;
+   }
 
    Int_t bufbegin = basket->GetKeylen();
    buf->SetBufferOffset(bufbegin);
@@ -1556,13 +1570,13 @@ Int_t TBranch::GetEntry(Long64_t entry, Int_t getall)
    // Remember which entry we are reading.
    fReadEntry = entry;
 
-   if (R__unlikely(TestBit(kDoNotProcess) && !getall)) {return 0;}
+   if (R__unlikely(TestBit(kDoNotProcess) && !getall)) { return 0; }
 
    TBasket *basket; // will be initialized in the if/then clauses.
    Long64_t first;
 
    Int_t result = GetBasketAndFirst(basket, first, nullptr);
-   if (R__unlikely(result <= 0)) {return result;}
+   if (R__unlikely(result <= 0)) { return result; }
 
    basket->PrepareBasket(entry);
    TBuffer* buf = basket->GetBufferRef();

--- a/tree/tree/src/TLeafD.cxx
+++ b/tree/tree/src/TLeafD.cxx
@@ -132,7 +132,7 @@ void TLeafD::ReadBasket(TBuffer &b)
 
 // Deserialize N events from an input buffer.
 bool TLeafD::ReadBasketFast(TBuffer &input_buf, Long64_t N) {
-  if (R__unlikely(fLeafCount)) {return false;}
+  if (R__unlikely(fLeafCount)) { return false; }
 
    Double_t *buf __attribute__((aligned(8)));
    buf = reinterpret_cast<Double_t*>(input_buf.GetCurrent());

--- a/tree/tree/src/TLeafElement.cxx
+++ b/tree/tree/src/TLeafElement.cxx
@@ -99,8 +99,7 @@ TLeafElement::GetDeserializeType() const
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Deserialize N events from an input buffer.
-bool
-TLeafElement::ReadBasketFast(TBuffer &input_buf, Long64_t N) {
+Bool_t TLeafElement::ReadBasketFast(TBuffer &input_buf, Long64_t N) {
 
    EDataType type = fDataTypeCache.load(std::memory_order_consume);
 

--- a/tree/tree/test/BulkApi.cxx
+++ b/tree/tree/test/BulkApi.cxx
@@ -1,4 +1,3 @@
-
 #include <stdio.h>
 
 #include "Bytes.h"
@@ -16,139 +15,137 @@
 
 #include "gtest/gtest.h"
 
-
 class BulkApiTest : public ::testing::Test {
 public:
-    static constexpr Int_t fEventCount = 1e7;
-    const std::string fFileName = "BulkApiTest.root";
+   static constexpr Int_t fEventCount = 1e7;
+   const std::string fFileName = "BulkApiTest.root";
 
 protected:
-    virtual void SetUp()
-    {
-        auto hfile = new TFile(fFileName.c_str(), "RECREATE", "TTree float micro benchmark ROOT file");
-        hfile->SetCompressionLevel(0); // No compression at all.
+   virtual void SetUp()
+   {
+      auto hfile = new TFile(fFileName.c_str(), "RECREATE", "TTree float micro benchmark ROOT file");
+      hfile->SetCompressionLevel(0); // No compression at all.
 
-        // Otherwise, we keep with the current ROOT defaults.
-        auto tree = new TTree("T", "A ROOT tree of floats.");
-        float f = 2;
-        TBranch *branch2 = tree->Branch("myFloat", &f, 320000, 1);
-        branch2->SetAutoDelete(kFALSE);
-        for (Long64_t ev = 0; ev < fEventCount; ev++) {
-          tree->Fill();
-          f ++;
-        }
-        hfile = tree->GetCurrentFile();
-        hfile->Write();
-        tree->Print();
-        printf("Successful write of all events.\n");
-        hfile->Close();
+      // Otherwise, we keep with the current ROOT defaults.
+      auto tree = new TTree("T", "A ROOT tree of floats.");
+      float f = 2;
+      TBranch *branch2 = tree->Branch("myFloat", &f, 320000, 1);
+      branch2->SetAutoDelete(kFALSE);
+      for (Long64_t ev = 0; ev < fEventCount; ev++) {
+        tree->Fill();
+        f ++;
+      }
+      hfile = tree->GetCurrentFile();
+      hfile->Write();
+      tree->Print();
+      printf("Successful write of all events.\n");
+      hfile->Close();
 
-        delete hfile;
-    }
+      delete hfile;
+   }
 };
-
 
 TEST_F(BulkApiTest, stdRead)
 {
-    auto hfile = TFile::Open(fFileName.c_str());
-    printf("Starting read of file %s.\n", fFileName.c_str());
-    TStopwatch sw;
+   auto hfile = TFile::Open(fFileName.c_str());
+   printf("Starting read of file %s.\n", fFileName.c_str());
+   TStopwatch sw;
 
-    printf("Using standard read APIs.\n");
-    // Read via standard APIs.
-    TTreeReader myReader("T", hfile);
-    TTreeReaderValue<float> myF(myReader, "myFloat");
-    Long64_t idx = 0;
-    float idx_f = 1;
-    Int_t events = fEventCount;
-    sw.Start();
-    while (myReader.Next()) {
-        if (R__unlikely(idx == events)) {break;}
-        idx_f++;
-        if (R__unlikely((idx < 16000000) && (*myF != idx_f))) {
-            printf("Incorrect value on myFloat branch: %f, expected %f (event %lld)\n", *myF, idx_f, idx);
-            ASSERT_TRUE(false);
-        }
-        idx++;
-    }
-    sw.Stop();
-    printf("TTreeReader: Successful read of all events.\n");
-    printf("TTreeReader: Total elapsed time (seconds) for standard APIs: %.2f\n", sw.RealTime());
+   printf("Using standard read APIs.\n");
+   // Read via standard APIs.
+   TTreeReader myReader("T", hfile);
+   TTreeReaderValue<float> myF(myReader, "myFloat");
+   Long64_t idx = 0;
+   float idx_f = 1;
+   Int_t events = fEventCount;
+   sw.Start();
+   while (myReader.Next()) {
+      if (R__unlikely(idx == events)) {break;}
+      idx_f++;
+      if (R__unlikely((idx < 16000000) && (*myF != idx_f))) {
+         printf("Incorrect value on myFloat branch: %f, expected %f (event %lld)\n", *myF, idx_f, idx);
+         ASSERT_TRUE(false);
+      }
+      idx++;
+   }
+   sw.Stop();
+   printf("TTreeReader: Successful read of all events.\n");
+   printf("TTreeReader: Total elapsed time (seconds) for standard APIs: %.2f\n", sw.RealTime());
 }
 
 TEST_F(BulkApiTest, simpleRead)
 {
-    auto hfile = TFile::Open(fFileName.c_str());
-    printf("Starting read of file %s.\n", fFileName.c_str());
-    TStopwatch sw;
+   auto hfile = TFile::Open(fFileName.c_str());
+   printf("Starting read of file %s.\n", fFileName.c_str());
+   TStopwatch sw;
 
-    printf("Using inline bulk read APIs.\n");
-    TBufferFile branchbuf(TBuffer::kWrite, 32*1024);
-    TTree *tree = dynamic_cast<TTree*>(hfile->Get("T"));
-    ASSERT_TRUE(tree);
+   printf("Using inline bulk read APIs.\n");
+   TBufferFile branchbuf(TBuffer::kWrite, 32*1024);
+   TTree *tree = dynamic_cast<TTree*>(hfile->Get("T"));
+   ASSERT_TRUE(tree);
 
-    TBranch *branchF = tree->GetBranch("myFloat");
-    ASSERT_TRUE(branchF);
+   TBranch *branchF = tree->GetBranch("myFloat");
+   ASSERT_TRUE(branchF);
 
-    Int_t events = fEventCount;
-    float idx_f = 1;
-    Long64_t evt_idx = 0;
-    while (events) {
-        auto count = branchF->GetBulkRead().GetEntriesSerialized(evt_idx, branchbuf);
-        ASSERT_GE(count, 0);
-        events = events > count ? (events - count) : 0;
+   Int_t events = fEventCount;
+   float idx_f = 1;
+   Long64_t evt_idx = 0;
+   while (events) {
+      auto count = branchF->GetBulkRead().GetEntriesSerialized(evt_idx, branchbuf);
+      ASSERT_GE(count, 0);
+      events = events > count ? (events - count) : 0;
 
-        float *entry = reinterpret_cast<float*>(branchbuf.GetCurrent());
-        for (Int_t idx=0; idx<count; idx++) {
-            idx_f++;
-            Int_t tmp = *reinterpret_cast<Int_t*>(&entry[idx]);
-            char *tmp_ptr = reinterpret_cast<char *>(&tmp);
-            frombuf(tmp_ptr, entry + idx);
+      float *entry = reinterpret_cast<float*>(branchbuf.GetCurrent());
+      for (Int_t idx=0; idx<count; idx++) {
+         idx_f++;
+         Int_t tmp = *reinterpret_cast<Int_t*>(&entry[idx]);
+         char *tmp_ptr = reinterpret_cast<char *>(&tmp);
+         frombuf(tmp_ptr, entry + idx);
 
-            if (R__unlikely((evt_idx < 16000000) && (entry[idx] != idx_f))) {
-                printf("Incorrect value on myFloat branch: %f (event %lld)\n", entry[idx], evt_idx + idx);
-                ASSERT_TRUE(false);
-            }
-        }
-        evt_idx += count;
-    }
-    sw.Stop();
-    printf("GetEntriesSerialized: Successful read of all events.\n");
-    printf("GetEntriesSerialized: Total elapsed time (seconds) for bulk APIs: %.2f\n", sw.RealTime());
+         if (R__unlikely((evt_idx < 16000000) && (entry[idx] != idx_f))) {
+             printf("Incorrect value on myFloat branch: %f (event %lld)\n", entry[idx], evt_idx + idx);
+             ASSERT_TRUE(false);
+         }
+      }
+      evt_idx += count;
+   }
+   sw.Stop();
+   printf("GetEntriesSerialized: Successful read of all events.\n");
+   printf("GetEntriesSerialized: Total elapsed time (seconds) for bulk APIs: %.2f\n", sw.RealTime());
 }
 
 TEST_F(BulkApiTest, fastRead)
 {
-    auto hfile = TFile::Open(fFileName.c_str());
-    printf("Starting read of file %s.\n", fFileName.c_str());
-    TStopwatch sw;
+   auto hfile = TFile::Open(fFileName.c_str());
+   printf("Starting read of file %s.\n", fFileName.c_str());
+   TStopwatch sw;
 
-    printf("Using TTreeReaderFast.\n");
-    ROOT::Experimental::TTreeReaderFast myReader("T", hfile);
-    ROOT::Experimental::TTreeReaderValueFast<float> myF(myReader, "myFloat");
-    myReader.SetEntry(0);
-    if (ROOT::Internal::TTreeReaderValueBase::kSetupMatch != myF.GetSetupStatus()) {
-        printf("TTreeReaderValueFast<float> failed to initialize.  Status code: %d\n", myF.GetSetupStatus());
-        ASSERT_TRUE(false);
-    }
-    if (myReader.GetEntryStatus() != TTreeReader::kEntryValid) {
-        printf("TTreeReaderFast failed to initialize.  Entry status: %d\n", myReader.GetEntryStatus());
-        ASSERT_TRUE(false);
-    }
-    Int_t events = fEventCount;
-    Long64_t idx = 0;
-    float idx_f = 1;
-    for (auto reader_idx : myReader) {
-        ASSERT_LT(reader_idx, events);
-        ASSERT_EQ(reader_idx, idx);
-        idx_f++;
-        if (R__unlikely((idx < 16000000) && (*myF != idx_f))) {
-            printf("Incorrect value on myFloat branch: %f, expected %f (event %lld)\n", *myF, idx_f, idx);
-            ASSERT_TRUE(false);
-        }
-        idx++;
-    }
-    sw.Stop();
-    printf("TTreeReaderFast: Successful read of all events.\n");
-    printf("TTreeReaderFast: Total elapsed time (seconds) for bulk APIs: %.2f\n", sw.RealTime());
+   printf("Using TTreeReaderFast.\n");
+   ROOT::Experimental::TTreeReaderFast myReader("T", hfile);
+   ROOT::Experimental::TTreeReaderValueFast<float> myF(myReader, "myFloat");
+   myReader.SetEntry(0);
+   if (ROOT::Internal::TTreeReaderValueBase::kSetupMatch != myF.GetSetupStatus()) {
+      printf("TTreeReaderValueFast<float> failed to initialize.  Status code: %d\n", myF.GetSetupStatus());
+      ASSERT_TRUE(false);
+   }
+   if (myReader.GetEntryStatus() != TTreeReader::kEntryValid) {
+      printf("TTreeReaderFast failed to initialize.  Entry status: %d\n", myReader.GetEntryStatus());
+      ASSERT_TRUE(false);
+   }
+   Int_t events = fEventCount;
+   Long64_t idx = 0;
+   float idx_f = 1;
+   for (auto reader_idx : myReader) {
+      ASSERT_LT(reader_idx, events);
+      ASSERT_EQ(reader_idx, idx);
+      idx_f++;
+      if (R__unlikely((idx < 16000000) && (*myF != idx_f))) {
+         printf("Incorrect value on myFloat branch: %f, expected %f (event %lld)\n", *myF, idx_f, idx);
+         ASSERT_TRUE(false);
+      }
+      idx++;
+   }
+   sw.Stop();
+   printf("TTreeReaderFast: Successful read of all events.\n");
+   printf("TTreeReaderFast: Total elapsed time (seconds) for bulk APIs: %.2f\n", sw.RealTime());
 }

--- a/tree/tree/test/BulkApiMultiple.cxx
+++ b/tree/tree/test/BulkApiMultiple.cxx
@@ -1,4 +1,3 @@
-
 #include <stdio.h>
 
 #include "TBranch.h"
@@ -12,126 +11,120 @@
 #include "ROOT/TTreeReaderValueFast.hxx"
 #include "ROOT/TBulkBranchRead.hxx"
 
-
 #include "gtest/gtest.h"
-
 
 class BulkApiMultipleTest : public ::testing::Test {
 public:
-    static constexpr Int_t fEventCount = 1e7;
-    const std::string fFileName = "BulkApiMultipleTest.root";
+   static constexpr Int_t fEventCount = 1e7;
+   const std::string fFileName = "BulkApiMultipleTest.root";
 
 protected:
-    virtual void SetUp()
-    {
-        auto hfile = new TFile(fFileName.c_str(), "RECREATE", "TTree float and double micro benchmark ROOT file");
-        hfile->SetCompressionLevel(0); // No compression at all.
+   virtual void SetUp()
+   {
+      auto hfile = new TFile(fFileName.c_str(), "RECREATE", "TTree float and double micro benchmark ROOT file");
+      hfile->SetCompressionLevel(0); // No compression at all.
 
-        // Otherwise, we keep with the current ROOT defaults.
-        auto tree = new TTree("T", "A ROOT tree of floats.");
-        float f = 2;
-        double g = 3;
-        TBranch *branch2 = tree->Branch("myFloat", &f, 320000, 1);
-        TBranch *branch3 = tree->Branch("myDouble", &g, 320000, 1);
-        branch2->SetAutoDelete(kFALSE);
-        branch3->SetAutoDelete(kFALSE);
-        for (Long64_t ev = 0; ev < fEventCount; ev++) {
-          tree->Fill();
-          f ++;
-          g ++;
-        }
-        hfile = tree->GetCurrentFile();
-        hfile->Write();
-        tree->Print();
-        printf("Successful write of all events.\n");
-        hfile->Close();
+      // Otherwise, we keep with the current ROOT defaults.
+      auto tree = new TTree("T", "A ROOT tree of floats.");
+      float f = 2;
+      double g = 3;
+      TBranch *branch2 = tree->Branch("myFloat", &f, 320000, 1);
+      TBranch *branch3 = tree->Branch("myDouble", &g, 320000, 1);
+      branch2->SetAutoDelete(kFALSE);
+      branch3->SetAutoDelete(kFALSE);
+      for (Long64_t ev = 0; ev < fEventCount; ev++) {
+         tree->Fill();
+         f ++;
+         g ++;
+      }
+      hfile = tree->GetCurrentFile();
+      hfile->Write();
+      tree->Print();
+      printf("Successful write of all events.\n");
+      hfile->Close();
 
-        delete hfile;
-    }
+      delete hfile;
+   }
 };
-
 
 TEST_F(BulkApiMultipleTest, stdRead)
 {
-    auto hfile = TFile::Open(fFileName.c_str());
-    printf("Starting read of file %s.\n", fFileName.c_str());
-    TStopwatch sw;
+   auto hfile = TFile::Open(fFileName.c_str());
+   printf("Starting read of file %s.\n", fFileName.c_str());
+   TStopwatch sw;
 
-    printf("Using inline bulk read APIs.\n");
-
-    printf("Using standard read APIs.\n");
-    // Read via standard APIs.
-    TTreeReader myReader("T", hfile);
-    TTreeReaderValue<float> myF(myReader, "myFloat");
-    TTreeReaderValue<double> myG(myReader, "myDouble");
-    Long64_t idx = 0;
-    float idx_f = 1;
-    double idx_g = 2;
-    Int_t events = fEventCount;
-    sw.Start();
-    while (myReader.Next()) {
-        if (R__unlikely(idx == events)) {break;}
-        idx_f++;
-        idx_g++;
-        if (R__unlikely((idx < 16000000) && (*myF != idx_f))) {
-            printf("Incorrect value on myFloat branch: %f, expected %f (event %lld)\n", *myF, idx_f, idx);
-            ASSERT_TRUE(false);
-        }
-        if (R__unlikely((idx < 15000000) && (*myG != idx_g))) {
-            printf("Incorrect value on myDouble branch: %f, expected %f (event %lld)\n", *myG, idx_g, idx);
-            ASSERT_TRUE(false);
-        }
-        idx++;
-    }
-    sw.Stop();
-    printf("TTreeReader: Successful read of all events.\n");
-    printf("TTreeReader: Total elapsed time (seconds) for standard APIs: %.2f\n", sw.RealTime());
+   printf("Using standard read APIs.\n");
+   // Read via standard APIs.
+   TTreeReader myReader("T", hfile);
+   TTreeReaderValue<float> myF(myReader, "myFloat");
+   TTreeReaderValue<double> myG(myReader, "myDouble");
+   Long64_t idx = 0;
+   float idx_f = 1;
+   double idx_g = 2;
+   Int_t events = fEventCount;
+   sw.Start();
+   while (myReader.Next()) {
+      if (R__unlikely(idx == events)) {break;}
+      idx_f++;
+      idx_g++;
+      if (R__unlikely((idx < 16000000) && (*myF != idx_f))) {
+         printf("Incorrect value on myFloat branch: %f, expected %f (event %lld)\n", *myF, idx_f, idx);
+         ASSERT_TRUE(false);
+      }
+      if (R__unlikely((idx < 15000000) && (*myG != idx_g))) {
+         printf("Incorrect value on myDouble branch: %f, expected %f (event %lld)\n", *myG, idx_g, idx);
+         ASSERT_TRUE(false);
+      }
+      idx++;
+   }
+   sw.Stop();
+   printf("TTreeReader: Successful read of all events.\n");
+   printf("TTreeReader: Total elapsed time (seconds) for standard APIs: %.2f\n", sw.RealTime());
 }
-
 
 TEST_F(BulkApiMultipleTest, fastRead)
 {
-    auto hfile = TFile::Open(fFileName.c_str());
-    printf("Starting read of file %s.\n", fFileName.c_str());
-    TStopwatch sw;
+   auto hfile = TFile::Open(fFileName.c_str());
+   printf("Starting read of file %s.\n", fFileName.c_str());
+   TStopwatch sw;
 
-    printf("Using TTreeReaderFast.\n");
-    ROOT::Experimental::TTreeReaderFast myReader("T", hfile);
-    ROOT::Experimental::TTreeReaderValueFast<float> myF(myReader, "myFloat");
-    ROOT::Experimental::TTreeReaderValueFast<double> myG(myReader, "myDouble");
-    myReader.SetEntry(0);
-    if (ROOT::Internal::TTreeReaderValueBase::kSetupMatch != myF.GetSetupStatus()) {
-        printf("TTreeReaderValueFast<float> failed to initialize.  Status code: %d\n", myF.GetSetupStatus());
-        ASSERT_TRUE(false);
-    }
-    if (ROOT::Internal::TTreeReaderValueBase::kSetupMatch != myG.GetSetupStatus()) {
-        printf("TTreeReaderValueFast<double> failed to initialize.  Status code: %d\n", myG.GetSetupStatus());
-        ASSERT_TRUE(false);
-    }
-    if (myReader.GetEntryStatus() != TTreeReader::kEntryValid) {
-        printf("TTreeReaderFast failed to initialize.  Entry status: %d\n", myReader.GetEntryStatus());
-        ASSERT_TRUE(false);
-    }
-    Int_t events = fEventCount;
-    Long64_t idx = 0;
-    float idx_f = 1;
-    double idx_g = 2;
-    for (auto reader_idx : myReader) {
-        ASSERT_LT(reader_idx, events);
-        ASSERT_EQ(reader_idx, idx);
-        idx_f++;
-        idx_g++;
-        if (R__unlikely((idx < 16000000) && (*myF != idx_f))) {
-            printf("Incorrect value on myFloat branch: %f, expected %f (event %lld)\n", *myF, idx_f, idx);
-            ASSERT_TRUE(false);
-        }
-        if (R__unlikely((idx < 15000000) && (*myG != idx_g))) {
-            printf("Incorrect value on myDouble branch: %f, expected %f (event %lld)\n", *myG, idx_g, idx);
-            ASSERT_TRUE(false);
-        }
-        idx++;
-    }
-    sw.Stop();
-    printf("TTreeReaderFast: Successful read of all events.\n");
-    printf("TTreeReaderFast: Total elapsed time (seconds) for bulk APIs: %.2f\n", sw.RealTime());
+   printf("Using TTreeReaderFast.\n");
+   ROOT::Experimental::TTreeReaderFast myReader("T", hfile);
+   ROOT::Experimental::TTreeReaderValueFast<float> myF(myReader, "myFloat");
+   ROOT::Experimental::TTreeReaderValueFast<double> myG(myReader, "myDouble");
+   myReader.SetEntry(0);
+   if (ROOT::Internal::TTreeReaderValueBase::kSetupMatch != myF.GetSetupStatus()) {
+      printf("TTreeReaderValueFast<float> failed to initialize.  Status code: %d\n", myF.GetSetupStatus());
+      ASSERT_TRUE(false);
+   }
+   if (ROOT::Internal::TTreeReaderValueBase::kSetupMatch != myG.GetSetupStatus()) {
+      printf("TTreeReaderValueFast<double> failed to initialize.  Status code: %d\n", myG.GetSetupStatus());
+      ASSERT_TRUE(false);
+   }
+   if (myReader.GetEntryStatus() != TTreeReader::kEntryValid) {
+      printf("TTreeReaderFast failed to initialize.  Entry status: %d\n", myReader.GetEntryStatus());
+      ASSERT_TRUE(false);
+   }
+   Int_t events = fEventCount;
+   Long64_t idx = 0;
+   float idx_f = 1;
+   double idx_g = 2;
+   for (auto reader_idx : myReader) {
+      ASSERT_LT(reader_idx, events);
+      ASSERT_EQ(reader_idx, idx);
+      idx_f++;
+      idx_g++;
+      if (R__unlikely((idx < 16000000) && (*myF != idx_f))) {
+         printf("Incorrect value on myFloat branch: %f, expected %f (event %lld)\n", *myF, idx_f, idx);
+         ASSERT_TRUE(false);
+      }
+      if (R__unlikely((idx < 15000000) && (*myG != idx_g))) {
+         printf("Incorrect value on myDouble branch: %f, expected %f (event %lld)\n", *myG, idx_g, idx);
+         ASSERT_TRUE(false);
+      }
+      idx++;
+   }
+   sw.Stop();
+   printf("TTreeReaderFast: Successful read of all events.\n");
+   printf("TTreeReaderFast: Total elapsed time (seconds) for bulk APIs: %.2f\n", sw.RealTime());
 }

--- a/tree/tree/test/BulkApiSillyStruct.cxx
+++ b/tree/tree/test/BulkApiSillyStruct.cxx
@@ -1,0 +1,152 @@
+#include <stdio.h>
+
+#include "Bytes.h"
+#include "Rtypes.h"
+#include "SillyStruct.h"
+#include "TBranch.h"
+#include "TBufferFile.h"
+#include "TFile.h"
+#include "TObject.h"
+#include "TStopwatch.h"
+#include "TTree.h"
+#include "TTreeReader.h"
+#include "TTreeReaderValue.h"
+#include "TTreeReaderArray.h"
+#include "ROOT/TTreeReaderFast.hxx"
+#include "ROOT/TTreeReaderValueFast.hxx"
+#include "ROOT/TBulkBranchRead.hxx"
+#include "ROOT/TIOFeatures.hxx"
+
+#include "gtest/gtest.h"
+
+class BulkApiSillyStructTest : public ::testing::Test {
+public:
+   static constexpr Long64_t fClusterSize = 1e5;
+   static constexpr Long64_t fEventCount = 4e6;
+   const std::string fFileName = "BulkApiSillyStruct.root";
+
+protected:
+   virtual void SetUp()
+   {
+      TFile *hfile = new TFile(fFileName.c_str(), "RECREATE", "TTree silly-struct benchmark");
+      hfile->SetCompressionLevel(0); // No compression at all.
+
+      TTree *tree = new TTree("T", "A ROOT tree of silly-struct branches.");
+      tree->SetBit(TTree::kOnlyFlushAtCluster);
+      tree->SetAutoFlush(fClusterSize);
+      ROOT::TIOFeatures features;
+      features.Set(ROOT::Experimental::EIOFeatures::kGenerateOffsetMap);
+      tree->SetIOFeatures(features);
+
+      SillyStruct ss;
+      TBranch *branch = tree->Branch("myEvent", &ss, 32000, 99);
+      branch->SetAutoDelete(kFALSE);
+
+      Int_t nb = 0;
+      for (Long64_t ev = 0; ev < fEventCount; ev++) {
+         ss.i = ev;
+         ss.f = ev;
+         ss.d = ev;
+         nb += tree->Fill();
+      } 
+
+      hfile = tree->GetCurrentFile();
+      hfile->Write();
+      tree->Print();
+      printf("Successful write of all events, nb = %d.\n", nb);
+
+      delete hfile;
+   }
+};
+
+constexpr Long64_t BulkApiSillyStructTest::fClusterSize;
+constexpr Long64_t BulkApiSillyStructTest::fEventCount;
+
+TEST_F(BulkApiSillyStructTest, stdReadStruct)
+{
+   auto hfile  = TFile::Open(fFileName.c_str());
+
+   TTreeReader myReader("T", hfile);
+   TTreeReaderValue<SillyStruct>  ss(myReader, "myEvent");
+
+   int    evI = 0;
+   float  evF = 0.0;
+   double evD = 0.0;
+   while (myReader.Next()) {
+      ASSERT_TRUE(ss->f == evF);
+      ASSERT_TRUE(ss->i == evI);
+      ASSERT_TRUE(ss->d == evD);
+      evI++;
+      evF++;
+      evD++;
+   }
+}
+
+TEST_F(BulkApiSillyStructTest, stdReadSplitBranch)
+{
+   auto hfile  = TFile::Open(fFileName.c_str());
+
+   TTreeReader myReader("T", hfile);
+   TTreeReaderValue<float>        myF(myReader, "f");
+   TTreeReaderValue<int>          myI(myReader, "i");
+   TTreeReaderValue<double>       myD(myReader, "d");
+
+   int    evI = 0;
+   float  evF = 0.0;
+   double evD = 0.0;
+   while (myReader.Next()) {
+      ASSERT_TRUE(*myF == evF);
+      ASSERT_TRUE(*myI == evI);
+      ASSERT_TRUE(*myD == evD);
+      evI++;
+      evF++;
+      evD++;
+   }
+}
+
+TEST_F(BulkApiSillyStructTest, fastRead)
+{
+   TBufferFile bufF(TBuffer::kWrite, 10000);
+   TBufferFile bufI(TBuffer::kWrite, 10000);
+   TBufferFile bufD(TBuffer::kWrite, 10000);
+   auto hfile  = TFile::Open(fFileName.c_str());
+   auto tree = dynamic_cast<TTree*>(hfile->Get("T"));
+   ASSERT_TRUE(tree);
+   TBranch *branchF = tree->GetBranch("f");
+   TBranch *branchI = tree->GetBranch("i");
+   TBranch *branchD = tree->GetBranch("d");
+
+   Long64_t events = fEventCount;
+   Int_t count = std::min(fClusterSize, fEventCount);
+   Long64_t evt_idx = 0;
+   int      evI = 0;
+   float    evF = 0.0;
+   double   evD = 0.0;
+
+   while (events) {
+      auto countF = branchF->GetBulkRead().GetEntriesFast(evt_idx, bufF);
+      auto countI = branchI->GetBulkRead().GetEntriesFast(evt_idx, bufI);
+      auto countD = branchD->GetBulkRead().GetEntriesFast(evt_idx, bufD);
+      ASSERT_EQ(countF, count);
+      ASSERT_EQ(countI, count);
+      ASSERT_EQ(countD, count);
+
+      if (events > count) {
+         events -= count;
+      } else {
+         events = 0;
+      }
+      float *float_buf = reinterpret_cast<float*>(bufF.GetCurrent());
+      double *double_buf = reinterpret_cast<double*>(bufD.GetCurrent());
+      int *int_buf = reinterpret_cast<int*>(bufI.GetCurrent());
+      for (Int_t idx = 0; idx < count; idx++) {
+         ASSERT_EQ(float_buf[idx], evF);
+         ASSERT_EQ(int_buf[idx], evI);
+         ASSERT_EQ(double_buf[idx], evD);
+         evF++;
+         evI++;
+         evD++;
+         evt_idx++;
+      }
+   }
+}

--- a/tree/tree/test/BulkApiVarLength.cxx
+++ b/tree/tree/test/BulkApiVarLength.cxx
@@ -1,4 +1,3 @@
-
 #include <stdio.h>
 
 #include "Bytes.h"
@@ -17,226 +16,223 @@
 
 #include "gtest/gtest.h"
 
-
 class BulkApiVariableTest : public ::testing::Test {
 public:
-    static constexpr Long64_t fClusterSize = 1e5;
-    static constexpr Long64_t fEventCount = 4e6;
-    const std::string fFileName = "BulkApiTestVarLength.root";
+   static constexpr Long64_t fClusterSize = 1e5;
+   static constexpr Long64_t fEventCount = 4e6;
+   const std::string fFileName = "BulkApiTestVarLength.root";
 
 protected:
-    virtual void SetUp()
-    {
-        auto hfile = new TFile(fFileName.c_str(), "RECREATE", "TTree float micro benchmark ROOT file");
-        hfile->SetCompressionLevel(0); // No compression at all.
+   virtual void SetUp()
+   {
+      auto hfile = new TFile(fFileName.c_str(), "RECREATE", "TTree float micro benchmark ROOT file");
+      hfile->SetCompressionLevel(0); // No compression at all.
 
-        auto tree = new TTree("T", "A ROOT tree of variable-length primitive branches.");
-        tree->SetBit(TTree::kOnlyFlushAtCluster);
-        tree->SetAutoFlush(fClusterSize);
-        ROOT::TIOFeatures features;
-        features.Set(ROOT::Experimental::EIOFeatures::kGenerateOffsetMap);
-        tree->SetIOFeatures(features);
+      auto tree = new TTree("T", "A ROOT tree of variable-length primitive branches.");
+      tree->SetBit(TTree::kOnlyFlushAtCluster);
+      tree->SetAutoFlush(fClusterSize);
+      ROOT::TIOFeatures features;
+      features.Set(ROOT::Experimental::EIOFeatures::kGenerateOffsetMap);
+      tree->SetIOFeatures(features);
 
-        float f_counter = 0;
-        float f[10];
-        double d[10];
-        int i[10];
-        int myLen = 0;
+      float f_counter = 0;
+      float f[10];
+      double d[10];
+      int i[10];
+      int myLen = 0;
 
-        tree->Branch("myLen", &myLen, "myLen/I", 32000);
-        auto branch2 = tree->Branch("f", &f, "f[myLen]/F", 32000);
-        auto branch3 = tree->Branch("d", &d, "d[myLen]/D", 32000);
-        auto branch4 = tree->Branch("i", &i, "i[myLen]/I", 32000);
-        branch2->SetAutoDelete(kFALSE);
-        branch3->SetAutoDelete(kFALSE);
-        branch4->SetAutoDelete(kFALSE);
-        for (Long64_t ev = 1; ev < fEventCount + 1; ev++) {
+      tree->Branch("myLen", &myLen, "myLen/I", 32000);
+      auto branch2 = tree->Branch("f", &f, "f[myLen]/F", 32000);
+      auto branch3 = tree->Branch("d", &d, "d[myLen]/D", 32000);
+      auto branch4 = tree->Branch("i", &i, "i[myLen]/I", 32000);
+      branch2->SetAutoDelete(kFALSE);
+      branch3->SetAutoDelete(kFALSE);
+      branch4->SetAutoDelete(kFALSE);
+      for (Long64_t ev = 1; ev < fEventCount + 1; ev++) {
 
-          for (Int_t idx = 0; idx < (ev % 10); idx++) {
+         for (Int_t idx = 0; idx < (ev % 10); idx++) {
             i[idx] = f_counter;
             f[idx] = f_counter++;
             d[idx] = f_counter + 1;
-          }
+         }
 
-          myLen = ev % 10;
-          tree->Fill();
-        } 
-        hfile = tree->GetCurrentFile();
-        hfile->Write();
-        tree->Print();
-        printf("Successful write of all events.\n");
+         myLen = ev % 10;
+         tree->Fill();
+      } 
+      hfile = tree->GetCurrentFile();
+      hfile->Write();
+      tree->Print();
+      printf("Successful write of all events.\n");
 
-        delete hfile;
-    }
+      delete hfile;
+   }
 };
+
 constexpr Long64_t BulkApiVariableTest::fClusterSize;
 constexpr Long64_t BulkApiVariableTest::fEventCount;
 
-
-
 TEST_F(BulkApiVariableTest, stdRead)
 {
-    auto hfile = TFile::Open(fFileName.c_str());
-    printf("Starting read of file %s.\n", fFileName.c_str());
-    TStopwatch sw;
+   auto hfile = TFile::Open(fFileName.c_str());
+   printf("Starting read of file %s.\n", fFileName.c_str());
+   TStopwatch sw;
 
-    printf("Using standard read APIs.\n");
+   printf("Using standard read APIs.\n");
 
-    TTreeReader myReader("T", hfile);
-    TTreeReaderArray<float> myF(myReader, "f");
-    TTreeReaderArray<double> myD(myReader, "d");
-    TTreeReaderValue<int> myI(myReader, "myLen");
-    Long64_t ev = 1;
-    float idx_f = 0;
-    double idx_g = 2;
-    Int_t events = fEventCount;
+   TTreeReader myReader("T", hfile);
+   TTreeReaderArray<float> myF(myReader, "f");
+   TTreeReaderArray<double> myD(myReader, "d");
+   TTreeReaderValue<int> myI(myReader, "myLen");
+   Long64_t ev = 1;
+   float idx_f = 0;
+   double idx_g = 2;
+   Int_t events = fEventCount;
 
-    sw.Start();
-    while (myReader.Next()) {
-        if (R__unlikely(*myI != (ev % 10))) {
-            printf("Incorrect number of entries on myLen branch: %d, expected %lld (event %lld)\n",
-                   *myI, ev % 10, ev);
+   sw.Start();
+   while (myReader.Next()) {
+      if (R__unlikely(*myI != (ev % 10))) {
+         printf("Incorrect number of entries on myLen branch: %d, expected %lld (event %lld)\n",
+                *myI, ev % 10, ev);
+         ASSERT_TRUE(false);
+      }         
+      if (R__unlikely(myF.GetSize() != static_cast<size_t>(ev % 10))) {
+         printf("Incorrect number of entries on float branch: %lu, expected %lld (event %lld)\n",
+                myF.GetSize(),
+                ev % 10,
+                ev);
+         ASSERT_TRUE(false);
+      }
+      if (R__unlikely(myD.GetSize() != static_cast<size_t>(ev % 10))) {
+         printf("Incorrect number of entries on double branch: %lu, expected %lld (event %lld)\n",
+                myD.GetSize(),
+                ev % 10,
+                ev);
+         ASSERT_TRUE(false);
+      }
+      for (int idx = 0; idx < *myI; idx++) {
+         float tree_f = myF[idx];
+         double tree_d = myD[idx];
+         if (R__unlikely((ev < 16000000) && (tree_f != idx_f))) {
+            printf("Incorrect value on float branch: %f, expected %f (event %lld, entry %d)\n",
+                   tree_f, idx_f, ev, idx);
             ASSERT_TRUE(false);
-        }         
-        if (R__unlikely(myF.GetSize() != static_cast<size_t>(ev % 10))) {
-            printf("Incorrect number of entries on float branch: %lu, expected %lld (event %lld)\n",
-                   myF.GetSize(),
-                   ev % 10,
-                   ev);
+         }
+         idx_f++;
+         if (R__unlikely((ev < 1600000) && (tree_d != idx_g))) {
+            printf("Incorrect value on double branch: %f, expected %f (event %lld, entry %d)\n",
+                   tree_d, idx_g, ev, idx);
             ASSERT_TRUE(false);
-        }
-        if (R__unlikely(myD.GetSize() != static_cast<size_t>(ev % 10))) {
-            printf("Incorrect number of entries on double branch: %lu, expected %lld (event %lld)\n",
-                   myD.GetSize(),
-                   ev % 10,
-                   ev);
-            ASSERT_TRUE(false);
-        }
-        for (int idx = 0; idx < *myI; idx++) {
-            float tree_f = myF[idx];
-            double tree_d = myD[idx];
-            if (R__unlikely((ev < 16000000) && (tree_f != idx_f))) {
-                printf("Incorrect value on float branch: %f, expected %f (event %lld, entry %d)\n",
-                       tree_f, idx_f, ev, idx);
-                ASSERT_TRUE(false);
-            }
-            idx_f++;
-            if (R__unlikely((ev < 1600000) && (tree_d != idx_g))) {
-                printf("Incorrect value on double branch: %f, expected %f (event %lld, entry %d)\n",
-                       tree_d, idx_g, ev, idx);
-                ASSERT_TRUE(false);
-            }
-            idx_g++;
-        }
-        ev++;
-    }
-    ASSERT_EQ(ev, events+1);
+         }
+         idx_g++;
+      }
+      ev++;
+   }
+   ASSERT_EQ(ev, events+1);
 
-    sw.Stop();
-    printf("TTreeReader: Successful read of all events.\n");
-    printf("TTreeReader: Total elapsed time (seconds) for standard APIs: %.2f\n", sw.RealTime());
+   sw.Stop();
+   printf("TTreeReader: Successful read of all events.\n");
+   printf("TTreeReader: Total elapsed time (seconds) for standard APIs: %.2f\n", sw.RealTime());
 }
 
 TEST_F(BulkApiVariableTest, serializedRead)
 {
-    auto hfile = TFile::Open(fFileName.c_str());
-    printf("Starting read of file %s.\n", fFileName.c_str());
-    TStopwatch sw;
+   auto hfile = TFile::Open(fFileName.c_str());
+   printf("Starting read of file %s.\n", fFileName.c_str());
+   TStopwatch sw;
 
-    printf("Using serialized bulk APIs.\n");
+   printf("Using serialized bulk APIs.\n");
 
-    auto tree = dynamic_cast<TTree*>(hfile->Get("T"));
-    ASSERT_TRUE(tree);
-    auto branchLen = tree->GetBranch("myLen");
-    ASSERT_TRUE(branchLen);
-    auto branchFloat = tree->GetBranch("f");
-    ASSERT_TRUE(branchFloat);
-    auto branchDouble = tree->GetBranch("d");
-    ASSERT_TRUE(branchDouble);
-    auto branchInt = tree->GetBranch("i");
-    ASSERT_TRUE(branchInt);
+   auto tree = dynamic_cast<TTree*>(hfile->Get("T"));
+   ASSERT_TRUE(tree);
+   auto branchLen = tree->GetBranch("myLen");
+   ASSERT_TRUE(branchLen);
+   auto branchFloat = tree->GetBranch("f");
+   ASSERT_TRUE(branchFloat);
+   auto branchDouble = tree->GetBranch("d");
+   ASSERT_TRUE(branchDouble);
+   auto branchInt = tree->GetBranch("i");
+   ASSERT_TRUE(branchInt);
 
-    int idx_i = 0;
-    float idx_f = 0;
-    double idx_d = 2;
-    Long64_t evt_idx = 0;
-    Long64_t events = fEventCount;
-    Int_t cluster_size = std::min(fClusterSize, fEventCount);
-    TBufferFile floatBuf(TBuffer::kWrite, 32*1024);
-    TBufferFile doubleBuf(TBuffer::kWrite, 32*1024);
-    TBufferFile intBuf(TBuffer::kWrite, 32*1024);
+   int idx_i = 0;
+   float idx_f = 0;
+   double idx_d = 2;
+   Long64_t evt_idx = 0;
+   Long64_t events = fEventCount;
+   Int_t cluster_size = std::min(fClusterSize, fEventCount);
+   TBufferFile floatBuf(TBuffer::kWrite, 32*1024);
+   TBufferFile doubleBuf(TBuffer::kWrite, 32*1024);
+   TBufferFile intBuf(TBuffer::kWrite, 32*1024);
     // Count buffer and len buffer should be identical.
-    TBufferFile countBuf(TBuffer::kWrite, 32*1024);
-    TBufferFile lenBuf(TBuffer::kWrite, 32*1024);
+   TBufferFile countBuf(TBuffer::kWrite, 32*1024);
+   TBufferFile lenBuf(TBuffer::kWrite, 32*1024);
 
-    while (events) {
-        auto count = branchFloat->GetBulkRead().GetEntriesSerialized(evt_idx, floatBuf, &countBuf);
-        ASSERT_EQ(count, cluster_size);
-        count = branchDouble->GetBulkRead().GetEntriesSerialized(evt_idx, doubleBuf);
-        ASSERT_EQ(count, cluster_size);
-        count = branchInt->GetBulkRead().GetEntriesSerialized(evt_idx, intBuf);
-        ASSERT_EQ(count, cluster_size);
-        count = branchLen->GetBulkRead().GetEntriesSerialized(evt_idx, lenBuf);
-        ASSERT_EQ(count, cluster_size);
+   while (events) {
+      auto count = branchFloat->GetBulkRead().GetEntriesSerialized(evt_idx, floatBuf, &countBuf);
+      ASSERT_EQ(count, cluster_size);
+      count = branchDouble->GetBulkRead().GetEntriesSerialized(evt_idx, doubleBuf);
+      ASSERT_EQ(count, cluster_size);
+      count = branchInt->GetBulkRead().GetEntriesSerialized(evt_idx, intBuf);
+      ASSERT_EQ(count, cluster_size);
+      count = branchLen->GetBulkRead().GetEntriesSerialized(evt_idx, lenBuf);
+      ASSERT_EQ(count, cluster_size);
 
-        if (events > count) {
-            events -= count;
-        } else {
-            events = 0;
-        }
-        char *float_buf = floatBuf.GetCurrent();
-        char *double_buf = doubleBuf.GetCurrent();
-        char *int_buf = intBuf.GetCurrent();
-        int *entry_count_buf = reinterpret_cast<int*>(countBuf.GetCurrent());
-        int *entry_len_buf = reinterpret_cast<int*>(countBuf.GetCurrent());
-        for (Int_t idx = 0; idx<count; idx++) {
-            int entry_count, entry_len;
-            char *tmp_buf = reinterpret_cast<char*>(entry_count_buf + idx);
-            frombuf(tmp_buf, &entry_count);
-            tmp_buf = reinterpret_cast<char*>(entry_len_buf + idx);
-            frombuf(tmp_buf, &entry_len);
-            //printf("Event %lld has %d entries.\n", evt_idx + idx + 1, entry_count);
-            // These should reference the same basket, just through different APIs.
-            ASSERT_EQ(entry_count, entry_len);
-            if (R__unlikely(entry_count != ((evt_idx + idx + 1) % 10))) {
-                printf("Incorrect number of entries on myLen branch: %d, expected %lld (event %lld)\n",
-                       entry_count, (evt_idx + idx + 1) % 10, evt_idx + idx);
+      if (events > count) {
+         events -= count;
+      } else {
+         events = 0;
+      }
+      char *float_buf = floatBuf.GetCurrent();
+      char *double_buf = doubleBuf.GetCurrent();
+      char *int_buf = intBuf.GetCurrent();
+      int *entry_count_buf = reinterpret_cast<int*>(countBuf.GetCurrent());
+      int *entry_len_buf = reinterpret_cast<int*>(countBuf.GetCurrent());
+      for (Int_t idx = 0; idx<count; idx++) {
+         int entry_count, entry_len;
+         char *tmp_buf = reinterpret_cast<char*>(entry_count_buf + idx);
+         frombuf(tmp_buf, &entry_count);
+         tmp_buf = reinterpret_cast<char*>(entry_len_buf + idx);
+         frombuf(tmp_buf, &entry_len);
+         //printf("Event %lld has %d entries.\n", evt_idx + idx + 1, entry_count);
+         // These should reference the same basket, just through different APIs.
+         ASSERT_EQ(entry_count, entry_len);
+         if (R__unlikely(entry_count != ((evt_idx + idx + 1) % 10))) {
+            printf("Incorrect number of entries on myLen branch: %d, expected %lld (event %lld)\n",
+                   entry_count, (evt_idx + idx + 1) % 10, evt_idx + idx);
+            ASSERT_TRUE(false);
+         }
+
+         for (int entry_idx=0; entry_idx<entry_count; entry_idx++) {
+            float entry_f;
+            frombuf(float_buf, &entry_f);
+            double entry_d;
+            frombuf(double_buf, &entry_d);
+            int entry_i;
+            frombuf(int_buf, &entry_i);
+            //printf("Event %lld entry %d (buffer %p) has int value %d\n", evt_idx + idx, entry_idx, int_buf, entry_i);
+            if (R__unlikely((evt_idx < 1600000) && (entry_i != idx_i))) {
+                printf("Incorrect value on int branch: %d, expected %d (event %lld, entry %d)\n", entry_i, idx_i, evt_idx + idx, entry_idx);
                 ASSERT_TRUE(false);
             }
-
-            for (int entry_idx=0; entry_idx<entry_count; entry_idx++) {
-                float entry_f;
-                frombuf(float_buf, &entry_f);
-                double entry_d;
-                frombuf(double_buf, &entry_d);
-                int entry_i;
-                frombuf(int_buf, &entry_i);
-                //printf("Event %lld entry %d (buffer %p) has int value %d\n", evt_idx + idx, entry_idx, int_buf, entry_i);
-                if (R__unlikely((evt_idx < 1600000) && (entry_i != idx_i))) {
-                    printf("Incorrect value on int branch: %d, expected %d (event %lld, entry %d)\n", entry_i, idx_i, evt_idx + idx, entry_idx);
-                    ASSERT_TRUE(false);
-                }
-                idx_i++;
-                //printf("Event %lld entry %d (buffer %p) has float value %f\n", evt_idx + idx, entry_idx, float_buf, entry_f);
-                if (R__unlikely((evt_idx < 1600000) && (entry_f != idx_f))) {
-                    printf("Incorrect value on float branch: %f, expected %f (diff %f, event %lld)\n", entry_f, idx_f, fabs(entry_f - idx_f), evt_idx + idx);
-                    ASSERT_TRUE(false);
-                }
-                idx_f++;
-                if (R__unlikely((evt_idx < 1600000) && (entry_d != idx_d))) {
-                    printf("Incorrect value on double branch: %f, expected %f (diff %f, event %lld)\n", entry_d, idx_d, fabs(entry_d - idx_d), evt_idx + idx);
-                    ASSERT_TRUE(false);
-                }
-                idx_d++;
+            idx_i++;
+            //printf("Event %lld entry %d (buffer %p) has float value %f\n", evt_idx + idx, entry_idx, float_buf, entry_f);
+            if (R__unlikely((evt_idx < 1600000) && (entry_f != idx_f))) {
+               printf("Incorrect value on float branch: %f, expected %f (diff %f, event %lld)\n", entry_f, idx_f, fabs(entry_f - idx_f), evt_idx + idx);
+               ASSERT_TRUE(false);
             }
+            idx_f++;
+            if (R__unlikely((evt_idx < 1600000) && (entry_d != idx_d))) {
+               printf("Incorrect value on double branch: %f, expected %f (diff %f, event %lld)\n", entry_d, idx_d, fabs(entry_d - idx_d), evt_idx + idx);
+               ASSERT_TRUE(false);
+            }
+            idx_d++;
+         }
+      }
+      evt_idx += count;
+   }
+   events = fEventCount;
+   ASSERT_EQ(evt_idx, events);
 
-        }
-        evt_idx += count;
-    }
-    events = fEventCount;
-    ASSERT_EQ(evt_idx, events);
-
-    sw.Stop();
-    printf("Bulk Serialized API: Successful read of all events.\n");
-    printf("Bulk Serialized API: Total elapsed time (seconds) for API: %.2f\n", sw.RealTime());
+   sw.Stop();
+   printf("Bulk Serialized API: Successful read of all events.\n");
+   printf("Bulk Serialized API: Total elapsed time (seconds) for API: %.2f\n", sw.RealTime());
 }

--- a/tree/tree/test/CMakeLists.txt
+++ b/tree/tree/test/CMakeLists.txt
@@ -1,7 +1,8 @@
-
+ROOT_STANDARD_LIBRARY_PACKAGE(SillyStruct NO_INSTALL_HEADER HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/SillyStruct.h SOURCES SillyStruct.cxx LINKDEF SillyStructLinkDef.h DEPENDENCIES RIO)
 ROOT_ADD_GTEST(testBulkApi BulkApi.cxx LIBRARIES RIO Tree TreePlayer)
 ROOT_ADD_GTEST(testBulkApiMultiple BulkApiMultiple.cxx LIBRARIES RIO Tree TreePlayer)
 ROOT_ADD_GTEST(testBulkApiVarLength BulkApiVarLength.cxx LIBRARIES RIO Tree TreePlayer)
+ROOT_ADD_GTEST(testBulkApiSillyStruct BulkApiSillyStruct.cxx LIBRARIES RIO Tree TreePlayer SillyStruct)
 ROOT_ADD_GTEST(testTBasket TBasket.cxx LIBRARIES RIO Tree)
 ROOT_ADD_GTEST(testTBranch TBranch.cxx LIBRARIES RIO Tree MathCore)
 ROOT_ADD_GTEST(testTIOFeatures TIOFeatures.cxx LIBRARIES RIO Tree)

--- a/tree/tree/test/SillyStruct.cxx
+++ b/tree/tree/test/SillyStruct.cxx
@@ -1,0 +1,3 @@
+#include "SillyStruct.h"
+
+ClassImp(SillyStruct)

--- a/tree/tree/test/SillyStruct.h
+++ b/tree/tree/test/SillyStruct.h
@@ -1,0 +1,17 @@
+#include "Rtypes.h"
+#include "TObject.h"
+
+/**
+ * The SillyStruct has no purpose except to provide
+ * inputs to the test cases.
+ */
+
+class SillyStruct : public TObject {
+
+public:
+   float  f;
+   int    i;
+   double d;
+
+   ClassDef(SillyStruct, 1)
+};

--- a/tree/tree/test/SillyStructLinkDef.h
+++ b/tree/tree/test/SillyStructLinkDef.h
@@ -1,0 +1,9 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+
+#pragma link C++ class SillyStruct+;
+
+#endif


### PR DESCRIPTION
1. Write three test cases for SillyStruct: standard read of SillyStruct objects; standard read of individual branches of SillyStruct objects; bulkapi read of individual branches.

2. Fix formatting of other test cases.