### PR TITLE
Change loop order to avoid branch operations

### DIFF
--- a/tree/dataframe/src/RRootBulkDS.cxx
+++ b/tree/dataframe/src/RRootBulkDS.cxx
@@ -32,9 +32,6 @@ private:
    // This is the mapping from col # to buffer.
    std::vector<TBufferFile*> fBufferMap;
 
-   // This is the mapping from col # to data type.
-   std::vector<EDataType> fDataTypeMap;
-
    // These are all the buffers that must be advanced by n bytes for each event.
    // 1 byte for bool/char, 2 bytes for short, 4 bytes for int/float and 8 bytes for double/long64
    std::vector<TBufferFile*> fOneByteBuffers;
@@ -76,7 +73,6 @@ public:
             printf("Skipping branch %s as we failed to retrieve the expected type info.\n", br->GetName());
             continue;
          }
-         fDataTypeMap.push_back(dt);
          if (dt == kChar_t || dt == kUChar_t || dt == kBool_t) {
             TBufferFile *bf = new TBufferFile(TBuffer::kWrite, 32*1024);
             fOneByteBuffers.push_back(bf);
@@ -115,20 +111,17 @@ public:
       for (auto idx : ROOT::TSeqU(fBufferMap.size())) {
          if (fBufferMap[idx]) delete fBufferMap[idx];
       }
-      for (auto idx : ROOT::TSeqU(fAddressMap.size())) {
-         if (fAddressMap[idx]) {
-            if (fDataTypeMap[idx] == kChar_t || fDataTypeMap[idx] == kUChar_t || fDataTypeMap[idx] == kBool_t) {
-               delete static_cast<Char_t*>(fAddressMap[idx]);
-            } else if (fDataTypeMap[idx] == kShort_t || fDataTypeMap[idx] == kUShort_t) {
-               delete static_cast<Short_t*>(fAddressMap[idx]);
-            } else if (fDataTypeMap[idx] == kFloat_t || fDataTypeMap[idx] == kInt_t || fDataTypeMap[idx] == kUInt_t) {
-               delete static_cast<Int_t*>(fAddressMap[idx]);
-            } else if (fDataTypeMap[idx] == kDouble_t || fDataTypeMap[idx] == kLong64_t || fDataTypeMap[idx] == kULong64_t) {
-               delete static_cast<Long64_t*>(fAddressMap[idx]);
-            } else {
-               printf("Unknown type\n");
-            }
-         }
+      for (UInt_t idx = 0; idx < fOneByteValues.size(); ++idx) {
+         if (fOneByteValues[idx]) delete fOneByteValues[idx];
+      }
+      for (UInt_t idx = 0; idx < fTwoByteValues.size(); ++idx) {
+         if (fTwoByteValues[idx]) delete fTwoByteValues[idx];
+      }
+      for (UInt_t idx = 0; idx < fFourByteValues.size(); ++idx) {
+         if (fFourByteValues[idx]) delete fFourByteValues[idx];
+      }
+      for (UInt_t idx = 0; idx < fEightByteValues.size(); ++idx) {
+         if (fEightByteValues[idx]) delete fEightByteValues[idx];
       }
    }
 
@@ -141,39 +134,29 @@ public:
       if (R__unlikely(fCurAbsEntry != entry)) {
           return false;
       }
-      auto idx1b = 0;
-      auto idx2b = 0;
-      auto idx4b = 0;
-      auto idx8b = 0;
-      for (UInt_t idx = 0; idx < fBufferMap.size(); ++idx) {
-         EDataType dt = fDataTypeMap[idx];
-         if (dt == kChar_t || dt == kUChar_t || dt == kBool_t) {
-            Char_t *raw_buffer = reinterpret_cast<Char_t*>(fBufferMap[idx]->GetCurrent());
-            Char_t tmp = *reinterpret_cast<Char_t*>(&raw_buffer[fCurRelEntry]);
-            char *tmp_ptr = reinterpret_cast<char *>(&tmp);
-            frombuf(tmp_ptr, fOneByteValues[idx1b]);
-            idx1b++;
-         } else if (dt == kShort_t || dt == kUShort_t) {
-            Short_t *raw_buffer = reinterpret_cast<Short_t*>(fBufferMap[idx]->GetCurrent());
-            Short_t tmp = *reinterpret_cast<Short_t*>(&raw_buffer[fCurRelEntry]);
-            char *tmp_ptr = reinterpret_cast<char *>(&tmp);
-            frombuf(tmp_ptr, fTwoByteValues[idx2b]);
-            idx2b++;
-         } else if (dt == kFloat_t || dt == kInt_t || dt == kUInt_t) {
-            Int_t *raw_buffer = reinterpret_cast<Int_t*>(fBufferMap[idx]->GetCurrent());
-            Int_t tmp = *reinterpret_cast<Int_t*>(&raw_buffer[fCurRelEntry]);
-            char *tmp_ptr = reinterpret_cast<char *>(&tmp);
-            frombuf(tmp_ptr, fFourByteValues[idx4b]);
-            idx4b++;
-         } else if (dt == kDouble_t || dt == kLong64_t || dt == kULong64_t) {
-            Long64_t *raw_buffer = reinterpret_cast<Long64_t*>(fBufferMap[idx]->GetCurrent());
-            Long64_t tmp = *reinterpret_cast<Long64_t*>(&raw_buffer[fCurRelEntry]);
-            char *tmp_ptr = reinterpret_cast<char *>(&tmp);
-            frombuf(tmp_ptr, fEightByteValues[idx8b]);
-            idx8b++;
-         } else {
-            printf("Unknown data type %d.\n", dt);
-         }
+      for (UInt_t idx = 0; idx < fOneByteBuffers.size(); ++idx) {
+         Char_t *raw_buffer = reinterpret_cast<Char_t*>(fOneByteBuffers[idx]->GetCurrent());
+         Char_t tmp = *reinterpret_cast<Char_t*>(&raw_buffer[fCurRelEntry]);
+         char *tmp_ptr = reinterpret_cast<char *>(&tmp);
+         frombuf(tmp_ptr, fOneByteValues[idx]);
+      }
+      for (UInt_t idx = 0; idx < fTwoByteBuffers.size(); ++idx) {
+         Short_t *raw_buffer = reinterpret_cast<Short_t*>(fTwoByteBuffers[idx]->GetCurrent());
+         Short_t tmp = *reinterpret_cast<Short_t*>(&raw_buffer[fCurRelEntry]);
+         char *tmp_ptr = reinterpret_cast<char *>(&tmp);
+         frombuf(tmp_ptr, fTwoByteValues[idx]);
+      }
+      for (UInt_t idx = 0; idx < fFourByteBuffers.size(); ++idx) {
+         Int_t *raw_buffer = reinterpret_cast<Int_t*>(fFourByteBuffers[idx]->GetCurrent());
+         Int_t tmp = *reinterpret_cast<Int_t*>(&raw_buffer[fCurRelEntry]);
+         char *tmp_ptr = reinterpret_cast<char *>(&tmp);
+         frombuf(tmp_ptr, fFourByteValues[idx]);
+      }
+      for (UInt_t idx = 0; idx < fEightByteBuffers.size(); ++idx) {
+         Long64_t *raw_buffer = reinterpret_cast<Long64_t*>(fEightByteBuffers[idx]->GetCurrent());
+         Long64_t tmp = *reinterpret_cast<Long64_t*>(&raw_buffer[fCurRelEntry]);
+         char *tmp_ptr = reinterpret_cast<char *>(&tmp);
+         frombuf(tmp_ptr, fEightByteValues[idx]);
       }
       fCurRelEntry++;
       fCurAbsEntry++;


### PR DESCRIPTION
Change loop order in SetEntry and ~TBulkBufferMgr to avoid branching Ops from if statements.